### PR TITLE
State abbreviation-based CSS classes for text replacement

### DIFF
--- a/cssclass.html
+++ b/cssclass.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>StateFace alternate CSS</title>
+    <link rel="stylesheet" href="reference/styles.css" type="text/css">
+    <link rel="stylesheet" href="reference/stateface.css" type="text/css">
+    <style>
+      table {
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <p>As an alternative to the StateFace code, you can use CSS classes
+       that correspond to a state's two-letter USPS abbreviation, either
+       to replace the text of an element with a state's shape, or to 
+       prepend to it.
+    </p>
+    <p><b>Replacement</b></p>
+    <p>
+      <code>
+        &lt;span class="state state-replace state-{abbrev}"&gt;{state}&lt;/span&gt;
+      </code>
+    </p>
+    <p>Example:</p>
+    <p>
+      <code>
+        &lt;span class="state state-replace state-md"&gt;Maryland&lt;/span&gt;
+      </code> &rarr;
+        <span class="state state-replace state-md">Maryland</span>
+    </p>
+
+    <p><b>Prepend</b></p>
+    <p>
+      <code>
+        &lt;span class="state state-{abbrev}"&gt;{state}&lt;/span&gt;
+      </code>
+    </p>
+    <p>Example:</p>
+    <p>
+      <code>
+        &lt;span class="state state-md"&gt;Maryland&lt;/span&gt;
+      </code> &rarr;
+        <span class="state state-md">Maryland</span>
+    </p>
+
+    <table>
+      <tr>
+        <th>Replacement</th>
+        <th>Prepend</th>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-al">Alabama</span></td>
+          <td><span class="state state-al">Alabama</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ak">Alaska</span></td>
+          <td><span class="state state-ak">Alaska</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-az">Arizona</span></td>
+          <td><span class="state state-az">Arizona</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ar">Arkansas</span></td>
+          <td><span class="state state-ar">Arkansas</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ca">California</span></td>
+          <td><span class="state state-ca">California</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-co">Colorado</span></td>
+          <td><span class="state state-co">Colorado</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ct">Connecticut</span></td>
+          <td><span class="state state-ct">Connecticut</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-dc">District of Columbia</span></td>
+          <td><span class="state state-dc">District of Columbia</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-fl">Florida</span></td>
+          <td><span class="state state-fl">Florida</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ga">Georgia</span></td>
+          <td><span class="state state-ga">Georgia</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-hi">Hawaii</span></td>
+          <td><span class="state state-hi">Hawaii</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-id">Idaho</span></td>
+          <td><span class="state state-id">Idaho</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-il">Illinois</span></td>
+          <td><span class="state state-il">Illinois</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-in">Indiana</span></td>
+          <td><span class="state state-in">Indiana</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ia">Iowa</span></td>
+          <td><span class="state state-ia">Iowa</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ks">Kansas</span></td>
+          <td><span class="state state-ks">Kansas</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ky">Kentucky</span></td>
+          <td><span class="state state-ky">Kentucky</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-la">Louisiana</span></td>
+          <td><span class="state state-la">Louisiana</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-me">Maine</span></td>
+          <td><span class="state state-me">Maine</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-md">Maryland</span></td>
+          <td><span class="state state-md">Maryland</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ma">Massachusetts</span></td>
+          <td><span class="state state-ma">Massachusetts</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-mi">Michigan</span></td>
+          <td><span class="state state-mi">Michigan</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-mn">Minnesota</span></td>
+          <td><span class="state state-mn">Minnesota</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ms">Mississippi</span></td>
+          <td><span class="state state-ms">Mississippi</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-mo">Missouri</span></td>
+          <td><span class="state state-mo">Missouri</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-mt">Montana</span></td>
+          <td><span class="state state-mt">Montana</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ne">Nebraska</span></td>
+          <td><span class="state state-ne">Nebraska</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-nv">Nevada</span></td>
+          <td><span class="state state-nv">Nevada</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-nh">New Hampshire</span></td>
+          <td><span class="state state-nh">New Hampshire</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-nj">New Jersey</span></td>
+          <td><span class="state state-nj">New Jersey</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-nm">New Mexico</span></td>
+          <td><span class="state state-nm">New Mexico</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ny">New York</span></td>
+          <td><span class="state state-ny">New York</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-nc">North Carolina</span></td>
+          <td><span class="state state-nc">North Carolina</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-nd">North Dakota</span></td>
+          <td><span class="state state-nd">North Dakota</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-oh">Ohio</span></td>
+          <td><span class="state state-oh">Ohio</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ok">Oklahoma</span></td>
+          <td><span class="state state-ok">Oklahoma</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-or">Oregon</span></td>
+          <td><span class="state state-or">Oregon</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-pa">Pennsylvania</span></td>
+          <td><span class="state state-pa">Pennsylvania</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ri">Rhode Island</span></td>
+          <td><span class="state state-ri">Rhode Island</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-sc">South Carolina</span></td>
+          <td><span class="state state-sc">South Carolina</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-sd">South Dakota</span></td>
+          <td><span class="state state-sd">South Dakota</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-tn">Tennessee</span></td>
+          <td><span class="state state-tn">Tennessee</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-tx">Texas</span></td>
+          <td><span class="state state-tx">Texas</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-ut">Utah</span></td>
+          <td><span class="state state-ut">Utah</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-vt">Vermont</span></td>
+          <td><span class="state state-vt">Vermont</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-va">Virginia</span></td>
+          <td><span class="state state-va">Virginia</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-wa">Washington</span></td>
+          <td><span class="state state-wa">Washington</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-wv">West Virginia</span></td>
+          <td><span class="state state-wv">West Virginia</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-wi">Wisconsin</span></td>
+          <td><span class="state state-wi">Wisconsin</span></td>
+      </tr>
+
+      <tr>
+          <td><span class="state state-replace state-wy">Wyoming</span></td>
+          <td><span class="state state-wy">Wyoming</span></td>
+      </tr>
+
+    </table>
+  </body>
+</html>
+

--- a/reference/cssclass.py
+++ b/reference/cssclass.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""
+Generates CSS rules for StateFace using state abbreviations rather than codes.
+
+Pass it the .json file containing the mapping between state abbrevations
+and StateFace code letters.
+"""
+from string import Template
+import sys
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+CLASS_PREFIX = 'state'
+
+CSS = Template("""\
+.$prefix:before {
+    font-family: StateFaceRegular;
+    margin-right: 5px;
+}
+
+.$prefix-replace {
+    text-indent: -999em;
+    display: inline-block;
+    position: relative;
+    min-width: 1em;
+}
+
+.$prefix-replace:before {
+    position: absolute;
+    left: 0;
+    top: 0;
+    text-indent: 0;
+}
+""").substitute(prefix=CLASS_PREFIX)
+
+STATE_RULE = Template("""\
+.$prefix-$abbrev:before {
+    content: "$code";
+}
+""").safe_substitute(prefix=CLASS_PREFIX)
+
+def make_state_rules(state_mapping):
+    rules = []
+    
+    for abbrev, code in sorted(state_mapping.iteritems()):
+        rule = Template(STATE_RULE).substitute(
+            abbrev=abbrev.lower(),
+            code=code
+        )
+        rules.append(rule)
+
+    return '\n'.join(rules)
+
+def main():
+    try:
+        f = open(sys.argv[1])
+    except IndexError:
+        f = sys.stdin
+    state_mapping = json.load(f)
+    print CSS
+    print make_state_rules(state_mapping)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/reference/stateface.css
+++ b/reference/stateface.css
@@ -1,0 +1,227 @@
+.state:before {
+    font-family: StateFaceRegular;
+    margin-right: 5px;
+}
+
+.state-replace {
+    text-indent: -999em;
+    display: inline-block;
+    position: relative;
+    min-width: 1em;
+}
+
+.state-replace:before {
+    position: absolute;
+    left: 0;
+    top: 0;
+    text-indent: 0;
+}
+
+.state-ak:before {
+    content: "A";
+}
+
+.state-al:before {
+    content: "B";
+}
+
+.state-ar:before {
+    content: "C";
+}
+
+.state-az:before {
+    content: "D";
+}
+
+.state-ca:before {
+    content: "E";
+}
+
+.state-co:before {
+    content: "F";
+}
+
+.state-ct:before {
+    content: "G";
+}
+
+.state-dc:before {
+    content: "y";
+}
+
+.state-de:before {
+    content: "H";
+}
+
+.state-fl:before {
+    content: "I";
+}
+
+.state-ga:before {
+    content: "J";
+}
+
+.state-hi:before {
+    content: "K";
+}
+
+.state-ia:before {
+    content: "L";
+}
+
+.state-id:before {
+    content: "M";
+}
+
+.state-il:before {
+    content: "N";
+}
+
+.state-in:before {
+    content: "O";
+}
+
+.state-ks:before {
+    content: "P";
+}
+
+.state-ky:before {
+    content: "Q";
+}
+
+.state-la:before {
+    content: "R";
+}
+
+.state-ma:before {
+    content: "S";
+}
+
+.state-md:before {
+    content: "T";
+}
+
+.state-me:before {
+    content: "U";
+}
+
+.state-mi:before {
+    content: "V";
+}
+
+.state-mn:before {
+    content: "W";
+}
+
+.state-mo:before {
+    content: "X";
+}
+
+.state-ms:before {
+    content: "Y";
+}
+
+.state-mt:before {
+    content: "Z";
+}
+
+.state-nc:before {
+    content: "a";
+}
+
+.state-nd:before {
+    content: "b";
+}
+
+.state-ne:before {
+    content: "c";
+}
+
+.state-nh:before {
+    content: "d";
+}
+
+.state-nj:before {
+    content: "e";
+}
+
+.state-nm:before {
+    content: "f";
+}
+
+.state-nv:before {
+    content: "g";
+}
+
+.state-ny:before {
+    content: "h";
+}
+
+.state-oh:before {
+    content: "i";
+}
+
+.state-ok:before {
+    content: "j";
+}
+
+.state-or:before {
+    content: "k";
+}
+
+.state-pa:before {
+    content: "l";
+}
+
+.state-ri:before {
+    content: "m";
+}
+
+.state-sc:before {
+    content: "n";
+}
+
+.state-sd:before {
+    content: "o";
+}
+
+.state-tn:before {
+    content: "p";
+}
+
+.state-tx:before {
+    content: "q";
+}
+
+.state-us:before {
+    content: "z";
+}
+
+.state-ut:before {
+    content: "r";
+}
+
+.state-va:before {
+    content: "s";
+}
+
+.state-vt:before {
+    content: "t";
+}
+
+.state-wa:before {
+    content: "u";
+}
+
+.state-wi:before {
+    content: "v";
+}
+
+.state-wv:before {
+    content: "w";
+}
+
+.state-wy:before {
+    content: "x";
+}
+


### PR DESCRIPTION
As an alternative to having to remember or lookup the right letter code to type for a state, one could use CSS classes where the class names are derived from the two-letter state USPS abbreviations. It’s also SEO-friendlier because you can write out the name of the state and have it replaced with the StateFace icon.

For example, instead of typing `T` to get an icon for Maryland:

``` html
<span class=".state .state-replace .state-md">Maryland</span>
```

If replacement is not required, omit `.state-replace` to have the icon prepended to the text:

``` html
<span class=".state .state-md">Maryland</span>
```

Perhaps since the common case is replacement, the `.state-replace` could be omitted and replacement would be the default, to be less verbose, and `.state-prepend` could be introduced for prepending.
