### PR TITLE
Update spelling in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html>
   <head>
@@ -21,7 +20,7 @@
 
 <h2>How to Use</h2>
 
-<p>The easiest way to us StateFace on the web is to use FontSquirrel's technique to serve StateFace in a reliably cross-platform way:</p>
+<p>The easiest way to use StateFace on the web is to use FontSquirrel's technique to serve StateFace in a reliably cross-platform way:</p>
 
 <ol>
 <li><p>In the <code>font/webfont</code> directory, find the following files and upload them to your webserver.</p>


### PR DESCRIPTION
Small spelling mishap on the first paragraph of the 'How to use' section.
