### PR TITLE
bowerify

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "stateface",
+  "version": "1.0.0",
+  "main": [
+    "font/webfont/stateface-regular-webfont.eot",
+    "font/webfont/stateface-regular-webfont.svg",
+    "font/webfont/stateface-regular-webfont.ttf",
+    "font/webfont/stateface-regular-webfont.woff",
+    "reference/stateface.css"
+  ],
+  "dependencies": { },
+  "devDependencies": { },
+  "ignore": [
+    "**/.*",
+    "**/*.txt",
+    "**/*.md",
+    "**/*.mdown",
+    "**/*.rb",
+    "**/*.json",
+    "**/*.py",
+    "**/*.html",
+    "eps",
+    "font/*.glyphs",
+    "font/*.otf",
+    "pkg",
+    "reference/styles.css",
+    "tools"
+  ]
+}


### PR DESCRIPTION
This allows users of [bower](http://bower.io) to bring this package into their projects with relative ease.

To fully make it work, you ideally will tag the repo with the value of `version` from the JSON file.  And, you should be able to distribute this from bower's central server as well.  Happy to help set it up if you think that's useful.