### PR TITLE
Add Sass Support for CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <link rel="stylesheet" href="reference/styles.css" type="text/css">
     <link rel="stylesheet" href="reference/stateface.css" type="text/css">
+    <link rel="stylesheet" href="reference/stateface-generated.css" type="text/css">
   </head>
   <body>
   <h1><div id="us">z<div id="ak">A</div><div id="hi">K</div></div> <strong>StateFace</strong></h1>
@@ -71,6 +72,25 @@
 <span class="stateface stateface-ca">California</span>.</p>
 
 <p>There is a full demo <a href="reference/cssclass.html">here</a>.</p>
+
+<h2>Sass &HorizontalLine; Compile CSS for icon replacement</h2>
+
+<p><a href="https://github.com/amurrell">Angela Murrell</a> wrote a <a href="reference/stateface-generated.css">Sass</a> file you can use in your Sass projects. It compiles to this CSS <a href="reference/stateface-generated.css">stylesheet</a>, but you could rewrite the Sass to generate custom CSS easily.
+
+<p>To use it to replace,</p>
+
+<pre><code>    &lt;span class="sf-new-mexico sf-replace"&gt;Words, and you must have them!&lt;/span&gt;
+</code></pre>
+
+<p>Many argue that <span class="sf-california sf-replace">california</span> is the best state.</p>
+
+<p>To use it to prepend,</p>
+
+<pre><code>    &lt;span class="sf-new-mexico"&gt;Words, prepended by a state icon.&lt;/span&gt;
+</code></pre>
+
+<p>Let's borrow that sentence again: I was born in <span class="sf-colorado">Colorado</span> and then moved to <span class="sf-florida">Florida</span>, and graduated from high school in
+<span class="sf-california">California</span>.</p>
 
 <h2>StateFace Keyboard Map</h2>
 

--- a/index.html
+++ b/index.html
@@ -77,6 +77,9 @@
 
 <p><a href="https://github.com/amurrell">Angela Murrell</a> wrote a <a href="reference/stateface-generated.css">Sass</a> file you can use in your Sass projects. It compiles to this CSS <a href="reference/stateface-generated.css">stylesheet</a>, but you could rewrite the Sass to generate custom CSS easily.
 
+<p>With this Sass file in place, this project will likely be easier to maintain.</p>
+<p><strong>Note:</strong> Support for Guam is in this Sass file, but it's not yet an icon.</p>
+
 <p>To use it to replace,</p>
 
 <pre><code>    &lt;span class="sf-new-mexico sf-replace"&gt;Words, and you must have them!&lt;/span&gt;
@@ -89,8 +92,24 @@
 <pre><code>    &lt;span class="sf-new-mexico"&gt;Words, prepended by a state icon.&lt;/span&gt;
 </code></pre>
 
-<p>Let's borrow that sentence again: I was born in <span class="sf-colorado">Colorado</span> and then moved to <span class="sf-florida">Florida</span>, and graduated from high school in
-<span class="sf-california">California</span>.</p>
+<p>Let's borrow that sentence again: I was born in <span class="sf-colorado">Colorado</span> and then moved to <span class="sf-fl">Florida</span>, and graduated from high school in
+<span class="sf-06">California</span>.</p>
+
+<h4>Added support for FIPS code, state-name, state abbreviation.</h4>
+<p>View <span class="sf-nh">New Hampshire example below:</span></p>
+
+<pre><code>    &lt;span class="sf-new-hampshire"&gt;Words, prepended by a state icon.&lt;/span&gt;
+</code></pre>
+<pre><code>    &lt;span class="sf-nh"&gt;Words, prepended by a state icon.&lt;/span&gt;
+</code></pre>
+<pre><code>    &lt;span class="sf-33"&gt;Words, prepended by a state icon.&lt;/span&gt;
+</code></pre>
+<pre><code>    &lt;span class="sf-new-hampshire sf-replace"&gt;Words, and you must have them!&lt;/span&gt;
+</code></pre>
+<pre><code>    &lt;span class="sf-nh sf-replace"&gt;Words, and you must have them!&lt;/span&gt;
+</code></pre>
+<pre><code>    &lt;span class="sf-33 sf-replace"&gt;Words, and you must have them!&lt;/span&gt;
+</code></pre>
 
 <h2>StateFace Keyboard Map</h2>
 

--- a/reference/stateface-generated.css
+++ b/reference/stateface-generated.css
@@ -1,0 +1,239 @@
+/*
+* SASS for http://propublica.github.io/stateface/ icon set.
+* author: https://github.com/amurrell
+*/
+@font-face {
+  font-family: 'sf-regular';
+  src: url("../font/webfont/stateface-regular-webfont.eot");
+  src: url("../font/webfont/stateface-regular-webfont.eot?#iefix") format("embedded-opentype"), url("../font/webfont/stateface-regular-webfont.woff") format("woff"), url("../font/webfont/stateface-regular-webfont.ttf") format("truetype"), url("../font/webfont/stateface-regular-webfont.svg#sf-regular") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+.sf-replace.sf-alabama, .sf-replace.sf-alaska, .sf-replace.sf-arizona, .sf-replace.sf-arkansas, .sf-replace.sf-california, .sf-replace.sf-colorado, .sf-replace.sf-connecticut, .sf-replace.sf-delaware, .sf-replace.sf-florida, .sf-replace.sf-georgia, .sf-replace.sf-hawaii, .sf-replace.sf-idaho, .sf-replace.sf-illinois, .sf-replace.sf-indiana, .sf-replace.sf-iowa, .sf-replace.sf-kansas, .sf-replace.sf-kentucky, .sf-replace.sf-louisiana, .sf-replace.sf-maine, .sf-replace.sf-maryland, .sf-replace.sf-massachusetts, .sf-replace.sf-michigan, .sf-replace.sf-minnesota, .sf-replace.sf-mississippi, .sf-replace.sf-missouri, .sf-replace.sf-montana, .sf-replace.sf-nebraska, .sf-replace.sf-nevada, .sf-replace.sf-new-hampshire, .sf-replace.sf-new-jersey, .sf-replace.sf-new-mexico, .sf-replace.sf-new-york, .sf-replace.sf-north-carolina, .sf-replace.sf-north-dakota, .sf-replace.sf-ohio, .sf-replace.sf-oklahoma, .sf-replace.sf-oregon, .sf-replace.sf-pennsylvania, .sf-replace.sf-rhode-island, .sf-replace.sf-south-carolina, .sf-replace.sf-south-dakota, .sf-replace.sf-tennessee, .sf-replace.sf-texas, .sf-replace.sf-utah, .sf-replace.sf-vermont, .sf-replace.sf-virginia, .sf-replace.sf-washington, .sf-replace.sf-west-virginia, .sf-replace.sf-wisconsin, .sf-replace.sf-wyoming {
+  text-indent: -999em;
+  display: inline-block;
+  position: relative;
+  min-width: 1em;
+}
+.sf-alabama:before, .sf-alaska:before, .sf-arizona:before, .sf-arkansas:before, .sf-california:before, .sf-colorado:before, .sf-connecticut:before, .sf-delaware:before, .sf-florida:before, .sf-georgia:before, .sf-hawaii:before, .sf-idaho:before, .sf-illinois:before, .sf-indiana:before, .sf-iowa:before, .sf-kansas:before, .sf-kentucky:before, .sf-louisiana:before, .sf-maine:before, .sf-maryland:before, .sf-massachusetts:before, .sf-michigan:before, .sf-minnesota:before, .sf-mississippi:before, .sf-missouri:before, .sf-montana:before, .sf-nebraska:before, .sf-nevada:before, .sf-new-hampshire:before, .sf-new-jersey:before, .sf-new-mexico:before, .sf-new-york:before, .sf-north-carolina:before, .sf-north-dakota:before, .sf-ohio:before, .sf-oklahoma:before, .sf-oregon:before, .sf-pennsylvania:before, .sf-rhode-island:before, .sf-south-carolina:before, .sf-south-dakota:before, .sf-tennessee:before, .sf-texas:before, .sf-utah:before, .sf-vermont:before, .sf-virginia:before, .sf-washington:before, .sf-west-virginia:before, .sf-wisconsin:before, .sf-wyoming:before {
+  font-family: "sf-regular";
+  margin-right: 5px;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+  font-weight: normal;
+  font-style: normal;
+  speak: none;
+  text-decoration: inherit;
+  text-transform: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.sf-replace.sf-alabama:before, .sf-replace.sf-alaska:before, .sf-replace.sf-arizona:before, .sf-replace.sf-arkansas:before, .sf-replace.sf-california:before, .sf-replace.sf-colorado:before, .sf-replace.sf-connecticut:before, .sf-replace.sf-delaware:before, .sf-replace.sf-florida:before, .sf-replace.sf-georgia:before, .sf-replace.sf-hawaii:before, .sf-replace.sf-idaho:before, .sf-replace.sf-illinois:before, .sf-replace.sf-indiana:before, .sf-replace.sf-iowa:before, .sf-replace.sf-kansas:before, .sf-replace.sf-kentucky:before, .sf-replace.sf-louisiana:before, .sf-replace.sf-maine:before, .sf-replace.sf-maryland:before, .sf-replace.sf-massachusetts:before, .sf-replace.sf-michigan:before, .sf-replace.sf-minnesota:before, .sf-replace.sf-mississippi:before, .sf-replace.sf-missouri:before, .sf-replace.sf-montana:before, .sf-replace.sf-nebraska:before, .sf-replace.sf-nevada:before, .sf-replace.sf-new-hampshire:before, .sf-replace.sf-new-jersey:before, .sf-replace.sf-new-mexico:before, .sf-replace.sf-new-york:before, .sf-replace.sf-north-carolina:before, .sf-replace.sf-north-dakota:before, .sf-replace.sf-ohio:before, .sf-replace.sf-oklahoma:before, .sf-replace.sf-oregon:before, .sf-replace.sf-pennsylvania:before, .sf-replace.sf-rhode-island:before, .sf-replace.sf-south-carolina:before, .sf-replace.sf-south-dakota:before, .sf-replace.sf-tennessee:before, .sf-replace.sf-texas:before, .sf-replace.sf-utah:before, .sf-replace.sf-vermont:before, .sf-replace.sf-virginia:before, .sf-replace.sf-washington:before, .sf-replace.sf-west-virginia:before, .sf-replace.sf-wisconsin:before, .sf-replace.sf-wyoming:before {
+  position: absolute;
+  left: 0;
+  top: 0;
+  text-indent: 0;
+}
+
+/* Icons */
+.sf-alabama:before {
+  content: "B";
+}
+
+.sf-alaska:before {
+  content: "A";
+}
+
+.sf-arizona:before {
+  content: "D";
+}
+
+.sf-arkansas:before {
+  content: "C";
+}
+
+.sf-california:before {
+  content: "E";
+}
+
+.sf-colorado:before {
+  content: "F";
+}
+
+.sf-connecticut:before {
+  content: "G";
+}
+
+.sf-delaware:before {
+  content: "H";
+}
+
+.sf-florida:before {
+  content: "I";
+}
+
+.sf-georgia:before {
+  content: "J";
+}
+
+.sf-hawaii:before {
+  content: "K";
+}
+
+.sf-idaho:before {
+  content: "M";
+}
+
+.sf-illinois:before {
+  content: "N";
+}
+
+.sf-indiana:before {
+  content: "O";
+}
+
+.sf-iowa:before {
+  content: "L";
+}
+
+.sf-kansas:before {
+  content: "P";
+}
+
+.sf-kentucky:before {
+  content: "Q";
+}
+
+.sf-louisiana:before {
+  content: "R";
+}
+
+.sf-maine:before {
+  content: "U";
+}
+
+.sf-maryland:before {
+  content: "T";
+}
+
+.sf-massachusetts:before {
+  content: "S";
+}
+
+.sf-michigan:before {
+  content: "V";
+}
+
+.sf-minnesota:before {
+  content: "W";
+}
+
+.sf-mississippi:before {
+  content: "Y";
+}
+
+.sf-missouri:before {
+  content: "X";
+}
+
+.sf-montana:before {
+  content: "Z";
+}
+
+.sf-nebraska:before {
+  content: "c";
+}
+
+.sf-nevada:before {
+  content: "g";
+}
+
+.sf-new-hampshire:before {
+  content: "d";
+}
+
+.sf-new-jersey:before {
+  content: "e";
+}
+
+.sf-new-mexico:before {
+  content: "f";
+}
+
+.sf-new-york:before {
+  content: "h";
+}
+
+.sf-north-carolina:before {
+  content: "a";
+}
+
+.sf-north-dakota:before {
+  content: "b";
+}
+
+.sf-ohio:before {
+  content: "i";
+}
+
+.sf-oklahoma:before {
+  content: "j";
+}
+
+.sf-oregon:before {
+  content: "k";
+}
+
+.sf-pennsylvania:before {
+  content: "l";
+}
+
+.sf-rhode-island:before {
+  content: "m";
+}
+
+.sf-south-carolina:before {
+  content: "n";
+}
+
+.sf-south-dakota:before {
+  content: "o";
+}
+
+.sf-tennessee:before {
+  content: "p";
+}
+
+.sf-texas:before {
+  content: "q";
+}
+
+.sf-utah:before {
+  content: "r";
+}
+
+.sf-vermont:before {
+  content: "t";
+}
+
+.sf-virginia:before {
+  content: "s";
+}
+
+.sf-washington:before {
+  content: "u";
+}
+
+.sf-west-virginia:before {
+  content: "w";
+}
+
+.sf-wisconsin:before {
+  content: "v";
+}
+
+.sf-wyoming:before {
+  content: "x";
+}

--- a/reference/stateface-generated.css
+++ b/reference/stateface-generated.css
@@ -1,6 +1,10 @@
 /*
 * SASS for http://propublica.github.io/stateface/ icon set.
 * author: https://github.com/amurrell
+
+* also adopted some code from other contributors:
+*  - replacement: Paul Smith https://github.com/paulsmith
+*  - FIPS state abbreviations: https://github.com/joetric
 */
 @font-face {
   font-family: 'sf-regular';
@@ -9,13 +13,225 @@
   font-weight: normal;
   font-style: normal;
 }
-.sf-replace.sf-alabama, .sf-replace.sf-alaska, .sf-replace.sf-arizona, .sf-replace.sf-arkansas, .sf-replace.sf-california, .sf-replace.sf-colorado, .sf-replace.sf-connecticut, .sf-replace.sf-delaware, .sf-replace.sf-florida, .sf-replace.sf-georgia, .sf-replace.sf-hawaii, .sf-replace.sf-idaho, .sf-replace.sf-illinois, .sf-replace.sf-indiana, .sf-replace.sf-iowa, .sf-replace.sf-kansas, .sf-replace.sf-kentucky, .sf-replace.sf-louisiana, .sf-replace.sf-maine, .sf-replace.sf-maryland, .sf-replace.sf-massachusetts, .sf-replace.sf-michigan, .sf-replace.sf-minnesota, .sf-replace.sf-mississippi, .sf-replace.sf-missouri, .sf-replace.sf-montana, .sf-replace.sf-nebraska, .sf-replace.sf-nevada, .sf-replace.sf-new-hampshire, .sf-replace.sf-new-jersey, .sf-replace.sf-new-mexico, .sf-replace.sf-new-york, .sf-replace.sf-north-carolina, .sf-replace.sf-north-dakota, .sf-replace.sf-ohio, .sf-replace.sf-oklahoma, .sf-replace.sf-oregon, .sf-replace.sf-pennsylvania, .sf-replace.sf-rhode-island, .sf-replace.sf-south-carolina, .sf-replace.sf-south-dakota, .sf-replace.sf-tennessee, .sf-replace.sf-texas, .sf-replace.sf-utah, .sf-replace.sf-vermont, .sf-replace.sf-virginia, .sf-replace.sf-washington, .sf-replace.sf-west-virginia, .sf-replace.sf-wisconsin, .sf-replace.sf-wyoming {
+.sf-replace.sf-alabama,
+.sf-replace.sf-al,
+.sf-replace.sf-01, .sf-replace.sf-alaska,
+.sf-replace.sf-ak,
+.sf-replace.sf-02, .sf-replace.sf-arizona,
+.sf-replace.sf-az,
+.sf-replace.sf-04, .sf-replace.sf-arkansas,
+.sf-replace.sf-ar,
+.sf-replace.sf-05, .sf-replace.sf-california,
+.sf-replace.sf-ca,
+.sf-replace.sf-06, .sf-replace.sf-colorado,
+.sf-replace.sf-co,
+.sf-replace.sf-08, .sf-replace.sf-connecticut,
+.sf-replace.sf-ct,
+.sf-replace.sf-09, .sf-replace.sf-delaware,
+.sf-replace.sf-de,
+.sf-replace.sf-10, .sf-replace.sf-florida,
+.sf-replace.sf-fl,
+.sf-replace.sf-12, .sf-replace.sf-georgia,
+.sf-replace.sf-ga,
+.sf-replace.sf-13, .sf-replace.sf-hawaii,
+.sf-replace.sf-hi,
+.sf-replace.sf-15, .sf-replace.sf-idaho,
+.sf-replace.sf-id,
+.sf-replace.sf-16, .sf-replace.sf-illinois,
+.sf-replace.sf-il,
+.sf-replace.sf-17, .sf-replace.sf-indiana,
+.sf-replace.sf-in,
+.sf-replace.sf-18, .sf-replace.sf-iowa,
+.sf-replace.sf-ia,
+.sf-replace.sf-19, .sf-replace.sf-kansas,
+.sf-replace.sf-ks,
+.sf-replace.sf-20, .sf-replace.sf-kentucky,
+.sf-replace.sf-ky,
+.sf-replace.sf-21, .sf-replace.sf-louisiana,
+.sf-replace.sf-la,
+.sf-replace.sf-22, .sf-replace.sf-maine,
+.sf-replace.sf-me,
+.sf-replace.sf-23, .sf-replace.sf-maryland,
+.sf-replace.sf-md,
+.sf-replace.sf-24, .sf-replace.sf-massachusetts,
+.sf-replace.sf-ma,
+.sf-replace.sf-25, .sf-replace.sf-michigan,
+.sf-replace.sf-mi,
+.sf-replace.sf-26, .sf-replace.sf-minnesota,
+.sf-replace.sf-mn,
+.sf-replace.sf-27, .sf-replace.sf-mississippi,
+.sf-replace.sf-ms,
+.sf-replace.sf-28, .sf-replace.sf-missouri,
+.sf-replace.sf-mo,
+.sf-replace.sf-29, .sf-replace.sf-montana,
+.sf-replace.sf-mt,
+.sf-replace.sf-30, .sf-replace.sf-nebraska,
+.sf-replace.sf-ne,
+.sf-replace.sf-31, .sf-replace.sf-nevada,
+.sf-replace.sf-nv,
+.sf-replace.sf-32, .sf-replace.sf-new-hampshire,
+.sf-replace.sf-nh,
+.sf-replace.sf-33, .sf-replace.sf-new-jersey,
+.sf-replace.sf-nj,
+.sf-replace.sf-34, .sf-replace.sf-new-mexico,
+.sf-replace.sf-nm,
+.sf-replace.sf-35, .sf-replace.sf-new-york,
+.sf-replace.sf-ny,
+.sf-replace.sf-36, .sf-replace.sf-north-carolina,
+.sf-replace.sf-nc,
+.sf-replace.sf-37, .sf-replace.sf-north-dakota,
+.sf-replace.sf-nd,
+.sf-replace.sf-38, .sf-replace.sf-ohio,
+.sf-replace.sf-oh,
+.sf-replace.sf-39, .sf-replace.sf-oklahoma,
+.sf-replace.sf-ok,
+.sf-replace.sf-40, .sf-replace.sf-oregon,
+.sf-replace.sf-or,
+.sf-replace.sf-41, .sf-replace.sf-pennsylvania,
+.sf-replace.sf-pa,
+.sf-replace.sf-42, .sf-replace.sf-rhode-island,
+.sf-replace.sf-ri,
+.sf-replace.sf-44, .sf-replace.sf-south-carolina,
+.sf-replace.sf-sc,
+.sf-replace.sf-45, .sf-replace.sf-south-dakota,
+.sf-replace.sf-sd,
+.sf-replace.sf-46, .sf-replace.sf-tennessee,
+.sf-replace.sf-tn,
+.sf-replace.sf-47, .sf-replace.sf-texas,
+.sf-replace.sf-tx,
+.sf-replace.sf-48, .sf-replace.sf-utah,
+.sf-replace.sf-ut,
+.sf-replace.sf-49, .sf-replace.sf-vermont,
+.sf-replace.sf-vt,
+.sf-replace.sf-50, .sf-replace.sf-virginia,
+.sf-replace.sf-va,
+.sf-replace.sf-51, .sf-replace.sf-washington,
+.sf-replace.sf-wa,
+.sf-replace.sf-53, .sf-replace.sf-west-virginia,
+.sf-replace.sf-wv,
+.sf-replace.sf-54, .sf-replace.sf-wisconsin,
+.sf-replace.sf-wi,
+.sf-replace.sf-55, .sf-replace.sf-wyoming,
+.sf-replace.sf-wy,
+.sf-replace.sf-56, .sf-replace.sf-district-of-columbia,
+.sf-replace.sf-dc,
+.sf-replace.sf-11001, .sf-replace.sf-puerto-rico,
+.sf-replace.sf-pr,
+.sf-replace.sf-72, .sf-replace.sf-guam,
+.sf-replace.sf-gu,
+.sf-replace.sf-66 {
   text-indent: -999em;
   display: inline-block;
   position: relative;
   min-width: 1em;
 }
-.sf-alabama:before, .sf-alaska:before, .sf-arizona:before, .sf-arkansas:before, .sf-california:before, .sf-colorado:before, .sf-connecticut:before, .sf-delaware:before, .sf-florida:before, .sf-georgia:before, .sf-hawaii:before, .sf-idaho:before, .sf-illinois:before, .sf-indiana:before, .sf-iowa:before, .sf-kansas:before, .sf-kentucky:before, .sf-louisiana:before, .sf-maine:before, .sf-maryland:before, .sf-massachusetts:before, .sf-michigan:before, .sf-minnesota:before, .sf-mississippi:before, .sf-missouri:before, .sf-montana:before, .sf-nebraska:before, .sf-nevada:before, .sf-new-hampshire:before, .sf-new-jersey:before, .sf-new-mexico:before, .sf-new-york:before, .sf-north-carolina:before, .sf-north-dakota:before, .sf-ohio:before, .sf-oklahoma:before, .sf-oregon:before, .sf-pennsylvania:before, .sf-rhode-island:before, .sf-south-carolina:before, .sf-south-dakota:before, .sf-tennessee:before, .sf-texas:before, .sf-utah:before, .sf-vermont:before, .sf-virginia:before, .sf-washington:before, .sf-west-virginia:before, .sf-wisconsin:before, .sf-wyoming:before {
+.sf-alabama:before,
+.sf-al:before,
+.sf-01:before, .sf-alaska:before,
+.sf-ak:before,
+.sf-02:before, .sf-arizona:before,
+.sf-az:before,
+.sf-04:before, .sf-arkansas:before,
+.sf-ar:before,
+.sf-05:before, .sf-california:before,
+.sf-ca:before,
+.sf-06:before, .sf-colorado:before,
+.sf-co:before,
+.sf-08:before, .sf-connecticut:before,
+.sf-ct:before,
+.sf-09:before, .sf-delaware:before,
+.sf-de:before,
+.sf-10:before, .sf-florida:before,
+.sf-fl:before,
+.sf-12:before, .sf-georgia:before,
+.sf-ga:before,
+.sf-13:before, .sf-hawaii:before,
+.sf-hi:before,
+.sf-15:before, .sf-idaho:before,
+.sf-id:before,
+.sf-16:before, .sf-illinois:before,
+.sf-il:before,
+.sf-17:before, .sf-indiana:before,
+.sf-in:before,
+.sf-18:before, .sf-iowa:before,
+.sf-ia:before,
+.sf-19:before, .sf-kansas:before,
+.sf-ks:before,
+.sf-20:before, .sf-kentucky:before,
+.sf-ky:before,
+.sf-21:before, .sf-louisiana:before,
+.sf-la:before,
+.sf-22:before, .sf-maine:before,
+.sf-me:before,
+.sf-23:before, .sf-maryland:before,
+.sf-md:before,
+.sf-24:before, .sf-massachusetts:before,
+.sf-ma:before,
+.sf-25:before, .sf-michigan:before,
+.sf-mi:before,
+.sf-26:before, .sf-minnesota:before,
+.sf-mn:before,
+.sf-27:before, .sf-mississippi:before,
+.sf-ms:before,
+.sf-28:before, .sf-missouri:before,
+.sf-mo:before,
+.sf-29:before, .sf-montana:before,
+.sf-mt:before,
+.sf-30:before, .sf-nebraska:before,
+.sf-ne:before,
+.sf-31:before, .sf-nevada:before,
+.sf-nv:before,
+.sf-32:before, .sf-new-hampshire:before,
+.sf-nh:before,
+.sf-33:before, .sf-new-jersey:before,
+.sf-nj:before,
+.sf-34:before, .sf-new-mexico:before,
+.sf-nm:before,
+.sf-35:before, .sf-new-york:before,
+.sf-ny:before,
+.sf-36:before, .sf-north-carolina:before,
+.sf-nc:before,
+.sf-37:before, .sf-north-dakota:before,
+.sf-nd:before,
+.sf-38:before, .sf-ohio:before,
+.sf-oh:before,
+.sf-39:before, .sf-oklahoma:before,
+.sf-ok:before,
+.sf-40:before, .sf-oregon:before,
+.sf-or:before,
+.sf-41:before, .sf-pennsylvania:before,
+.sf-pa:before,
+.sf-42:before, .sf-rhode-island:before,
+.sf-ri:before,
+.sf-44:before, .sf-south-carolina:before,
+.sf-sc:before,
+.sf-45:before, .sf-south-dakota:before,
+.sf-sd:before,
+.sf-46:before, .sf-tennessee:before,
+.sf-tn:before,
+.sf-47:before, .sf-texas:before,
+.sf-tx:before,
+.sf-48:before, .sf-utah:before,
+.sf-ut:before,
+.sf-49:before, .sf-vermont:before,
+.sf-vt:before,
+.sf-50:before, .sf-virginia:before,
+.sf-va:before,
+.sf-51:before, .sf-washington:before,
+.sf-wa:before,
+.sf-53:before, .sf-west-virginia:before,
+.sf-wv:before,
+.sf-54:before, .sf-wisconsin:before,
+.sf-wi:before,
+.sf-55:before, .sf-wyoming:before,
+.sf-wy:before,
+.sf-56:before, .sf-district-of-columbia:before,
+.sf-dc:before,
+.sf-11001:before, .sf-puerto-rico:before,
+.sf-pr:before,
+.sf-72:before, .sf-guam:before,
+.sf-gu:before,
+.sf-66:before {
   font-family: "sf-regular";
   margin-right: 5px;
   display: inline-block;
@@ -30,7 +246,113 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-.sf-replace.sf-alabama:before, .sf-replace.sf-alaska:before, .sf-replace.sf-arizona:before, .sf-replace.sf-arkansas:before, .sf-replace.sf-california:before, .sf-replace.sf-colorado:before, .sf-replace.sf-connecticut:before, .sf-replace.sf-delaware:before, .sf-replace.sf-florida:before, .sf-replace.sf-georgia:before, .sf-replace.sf-hawaii:before, .sf-replace.sf-idaho:before, .sf-replace.sf-illinois:before, .sf-replace.sf-indiana:before, .sf-replace.sf-iowa:before, .sf-replace.sf-kansas:before, .sf-replace.sf-kentucky:before, .sf-replace.sf-louisiana:before, .sf-replace.sf-maine:before, .sf-replace.sf-maryland:before, .sf-replace.sf-massachusetts:before, .sf-replace.sf-michigan:before, .sf-replace.sf-minnesota:before, .sf-replace.sf-mississippi:before, .sf-replace.sf-missouri:before, .sf-replace.sf-montana:before, .sf-replace.sf-nebraska:before, .sf-replace.sf-nevada:before, .sf-replace.sf-new-hampshire:before, .sf-replace.sf-new-jersey:before, .sf-replace.sf-new-mexico:before, .sf-replace.sf-new-york:before, .sf-replace.sf-north-carolina:before, .sf-replace.sf-north-dakota:before, .sf-replace.sf-ohio:before, .sf-replace.sf-oklahoma:before, .sf-replace.sf-oregon:before, .sf-replace.sf-pennsylvania:before, .sf-replace.sf-rhode-island:before, .sf-replace.sf-south-carolina:before, .sf-replace.sf-south-dakota:before, .sf-replace.sf-tennessee:before, .sf-replace.sf-texas:before, .sf-replace.sf-utah:before, .sf-replace.sf-vermont:before, .sf-replace.sf-virginia:before, .sf-replace.sf-washington:before, .sf-replace.sf-west-virginia:before, .sf-replace.sf-wisconsin:before, .sf-replace.sf-wyoming:before {
+.sf-replace.sf-alabama:before,
+.sf-replace.sf-al:before,
+.sf-replace.sf-01:before, .sf-replace.sf-alaska:before,
+.sf-replace.sf-ak:before,
+.sf-replace.sf-02:before, .sf-replace.sf-arizona:before,
+.sf-replace.sf-az:before,
+.sf-replace.sf-04:before, .sf-replace.sf-arkansas:before,
+.sf-replace.sf-ar:before,
+.sf-replace.sf-05:before, .sf-replace.sf-california:before,
+.sf-replace.sf-ca:before,
+.sf-replace.sf-06:before, .sf-replace.sf-colorado:before,
+.sf-replace.sf-co:before,
+.sf-replace.sf-08:before, .sf-replace.sf-connecticut:before,
+.sf-replace.sf-ct:before,
+.sf-replace.sf-09:before, .sf-replace.sf-delaware:before,
+.sf-replace.sf-de:before,
+.sf-replace.sf-10:before, .sf-replace.sf-florida:before,
+.sf-replace.sf-fl:before,
+.sf-replace.sf-12:before, .sf-replace.sf-georgia:before,
+.sf-replace.sf-ga:before,
+.sf-replace.sf-13:before, .sf-replace.sf-hawaii:before,
+.sf-replace.sf-hi:before,
+.sf-replace.sf-15:before, .sf-replace.sf-idaho:before,
+.sf-replace.sf-id:before,
+.sf-replace.sf-16:before, .sf-replace.sf-illinois:before,
+.sf-replace.sf-il:before,
+.sf-replace.sf-17:before, .sf-replace.sf-indiana:before,
+.sf-replace.sf-in:before,
+.sf-replace.sf-18:before, .sf-replace.sf-iowa:before,
+.sf-replace.sf-ia:before,
+.sf-replace.sf-19:before, .sf-replace.sf-kansas:before,
+.sf-replace.sf-ks:before,
+.sf-replace.sf-20:before, .sf-replace.sf-kentucky:before,
+.sf-replace.sf-ky:before,
+.sf-replace.sf-21:before, .sf-replace.sf-louisiana:before,
+.sf-replace.sf-la:before,
+.sf-replace.sf-22:before, .sf-replace.sf-maine:before,
+.sf-replace.sf-me:before,
+.sf-replace.sf-23:before, .sf-replace.sf-maryland:before,
+.sf-replace.sf-md:before,
+.sf-replace.sf-24:before, .sf-replace.sf-massachusetts:before,
+.sf-replace.sf-ma:before,
+.sf-replace.sf-25:before, .sf-replace.sf-michigan:before,
+.sf-replace.sf-mi:before,
+.sf-replace.sf-26:before, .sf-replace.sf-minnesota:before,
+.sf-replace.sf-mn:before,
+.sf-replace.sf-27:before, .sf-replace.sf-mississippi:before,
+.sf-replace.sf-ms:before,
+.sf-replace.sf-28:before, .sf-replace.sf-missouri:before,
+.sf-replace.sf-mo:before,
+.sf-replace.sf-29:before, .sf-replace.sf-montana:before,
+.sf-replace.sf-mt:before,
+.sf-replace.sf-30:before, .sf-replace.sf-nebraska:before,
+.sf-replace.sf-ne:before,
+.sf-replace.sf-31:before, .sf-replace.sf-nevada:before,
+.sf-replace.sf-nv:before,
+.sf-replace.sf-32:before, .sf-replace.sf-new-hampshire:before,
+.sf-replace.sf-nh:before,
+.sf-replace.sf-33:before, .sf-replace.sf-new-jersey:before,
+.sf-replace.sf-nj:before,
+.sf-replace.sf-34:before, .sf-replace.sf-new-mexico:before,
+.sf-replace.sf-nm:before,
+.sf-replace.sf-35:before, .sf-replace.sf-new-york:before,
+.sf-replace.sf-ny:before,
+.sf-replace.sf-36:before, .sf-replace.sf-north-carolina:before,
+.sf-replace.sf-nc:before,
+.sf-replace.sf-37:before, .sf-replace.sf-north-dakota:before,
+.sf-replace.sf-nd:before,
+.sf-replace.sf-38:before, .sf-replace.sf-ohio:before,
+.sf-replace.sf-oh:before,
+.sf-replace.sf-39:before, .sf-replace.sf-oklahoma:before,
+.sf-replace.sf-ok:before,
+.sf-replace.sf-40:before, .sf-replace.sf-oregon:before,
+.sf-replace.sf-or:before,
+.sf-replace.sf-41:before, .sf-replace.sf-pennsylvania:before,
+.sf-replace.sf-pa:before,
+.sf-replace.sf-42:before, .sf-replace.sf-rhode-island:before,
+.sf-replace.sf-ri:before,
+.sf-replace.sf-44:before, .sf-replace.sf-south-carolina:before,
+.sf-replace.sf-sc:before,
+.sf-replace.sf-45:before, .sf-replace.sf-south-dakota:before,
+.sf-replace.sf-sd:before,
+.sf-replace.sf-46:before, .sf-replace.sf-tennessee:before,
+.sf-replace.sf-tn:before,
+.sf-replace.sf-47:before, .sf-replace.sf-texas:before,
+.sf-replace.sf-tx:before,
+.sf-replace.sf-48:before, .sf-replace.sf-utah:before,
+.sf-replace.sf-ut:before,
+.sf-replace.sf-49:before, .sf-replace.sf-vermont:before,
+.sf-replace.sf-vt:before,
+.sf-replace.sf-50:before, .sf-replace.sf-virginia:before,
+.sf-replace.sf-va:before,
+.sf-replace.sf-51:before, .sf-replace.sf-washington:before,
+.sf-replace.sf-wa:before,
+.sf-replace.sf-53:before, .sf-replace.sf-west-virginia:before,
+.sf-replace.sf-wv:before,
+.sf-replace.sf-54:before, .sf-replace.sf-wisconsin:before,
+.sf-replace.sf-wi:before,
+.sf-replace.sf-55:before, .sf-replace.sf-wyoming:before,
+.sf-replace.sf-wy:before,
+.sf-replace.sf-56:before, .sf-replace.sf-district-of-columbia:before,
+.sf-replace.sf-dc:before,
+.sf-replace.sf-11001:before, .sf-replace.sf-puerto-rico:before,
+.sf-replace.sf-pr:before,
+.sf-replace.sf-72:before, .sf-replace.sf-guam:before,
+.sf-replace.sf-gu:before,
+.sf-replace.sf-66:before {
   position: absolute;
   left: 0;
   top: 0;
@@ -38,202 +360,320 @@
 }
 
 /* Icons */
-.sf-alabama:before {
+.sf-alabama:before,
+.sf-al:before,
+.sf-01:before {
   content: "B";
 }
 
-.sf-alaska:before {
+.sf-alaska:before,
+.sf-ak:before,
+.sf-02:before {
   content: "A";
 }
 
-.sf-arizona:before {
+.sf-arizona:before,
+.sf-az:before,
+.sf-04:before {
   content: "D";
 }
 
-.sf-arkansas:before {
+.sf-arkansas:before,
+.sf-ar:before,
+.sf-05:before {
   content: "C";
 }
 
-.sf-california:before {
+.sf-california:before,
+.sf-ca:before,
+.sf-06:before {
   content: "E";
 }
 
-.sf-colorado:before {
+.sf-colorado:before,
+.sf-co:before,
+.sf-08:before {
   content: "F";
 }
 
-.sf-connecticut:before {
+.sf-connecticut:before,
+.sf-ct:before,
+.sf-09:before {
   content: "G";
 }
 
-.sf-delaware:before {
+.sf-delaware:before,
+.sf-de:before,
+.sf-10:before {
   content: "H";
 }
 
-.sf-florida:before {
+.sf-florida:before,
+.sf-fl:before,
+.sf-12:before {
   content: "I";
 }
 
-.sf-georgia:before {
+.sf-georgia:before,
+.sf-ga:before,
+.sf-13:before {
   content: "J";
 }
 
-.sf-hawaii:before {
+.sf-hawaii:before,
+.sf-hi:before,
+.sf-15:before {
   content: "K";
 }
 
-.sf-idaho:before {
+.sf-idaho:before,
+.sf-id:before,
+.sf-16:before {
   content: "M";
 }
 
-.sf-illinois:before {
+.sf-illinois:before,
+.sf-il:before,
+.sf-17:before {
   content: "N";
 }
 
-.sf-indiana:before {
+.sf-indiana:before,
+.sf-in:before,
+.sf-18:before {
   content: "O";
 }
 
-.sf-iowa:before {
+.sf-iowa:before,
+.sf-ia:before,
+.sf-19:before {
   content: "L";
 }
 
-.sf-kansas:before {
+.sf-kansas:before,
+.sf-ks:before,
+.sf-20:before {
   content: "P";
 }
 
-.sf-kentucky:before {
+.sf-kentucky:before,
+.sf-ky:before,
+.sf-21:before {
   content: "Q";
 }
 
-.sf-louisiana:before {
+.sf-louisiana:before,
+.sf-la:before,
+.sf-22:before {
   content: "R";
 }
 
-.sf-maine:before {
+.sf-maine:before,
+.sf-me:before,
+.sf-23:before {
   content: "U";
 }
 
-.sf-maryland:before {
+.sf-maryland:before,
+.sf-md:before,
+.sf-24:before {
   content: "T";
 }
 
-.sf-massachusetts:before {
+.sf-massachusetts:before,
+.sf-ma:before,
+.sf-25:before {
   content: "S";
 }
 
-.sf-michigan:before {
+.sf-michigan:before,
+.sf-mi:before,
+.sf-26:before {
   content: "V";
 }
 
-.sf-minnesota:before {
+.sf-minnesota:before,
+.sf-mn:before,
+.sf-27:before {
   content: "W";
 }
 
-.sf-mississippi:before {
+.sf-mississippi:before,
+.sf-ms:before,
+.sf-28:before {
   content: "Y";
 }
 
-.sf-missouri:before {
+.sf-missouri:before,
+.sf-mo:before,
+.sf-29:before {
   content: "X";
 }
 
-.sf-montana:before {
+.sf-montana:before,
+.sf-mt:before,
+.sf-30:before {
   content: "Z";
 }
 
-.sf-nebraska:before {
+.sf-nebraska:before,
+.sf-ne:before,
+.sf-31:before {
   content: "c";
 }
 
-.sf-nevada:before {
+.sf-nevada:before,
+.sf-nv:before,
+.sf-32:before {
   content: "g";
 }
 
-.sf-new-hampshire:before {
+.sf-new-hampshire:before,
+.sf-nh:before,
+.sf-33:before {
   content: "d";
 }
 
-.sf-new-jersey:before {
+.sf-new-jersey:before,
+.sf-nj:before,
+.sf-34:before {
   content: "e";
 }
 
-.sf-new-mexico:before {
+.sf-new-mexico:before,
+.sf-nm:before,
+.sf-35:before {
   content: "f";
 }
 
-.sf-new-york:before {
+.sf-new-york:before,
+.sf-ny:before,
+.sf-36:before {
   content: "h";
 }
 
-.sf-north-carolina:before {
+.sf-north-carolina:before,
+.sf-nc:before,
+.sf-37:before {
   content: "a";
 }
 
-.sf-north-dakota:before {
+.sf-north-dakota:before,
+.sf-nd:before,
+.sf-38:before {
   content: "b";
 }
 
-.sf-ohio:before {
+.sf-ohio:before,
+.sf-oh:before,
+.sf-39:before {
   content: "i";
 }
 
-.sf-oklahoma:before {
+.sf-oklahoma:before,
+.sf-ok:before,
+.sf-40:before {
   content: "j";
 }
 
-.sf-oregon:before {
+.sf-oregon:before,
+.sf-or:before,
+.sf-41:before {
   content: "k";
 }
 
-.sf-pennsylvania:before {
+.sf-pennsylvania:before,
+.sf-pa:before,
+.sf-42:before {
   content: "l";
 }
 
-.sf-rhode-island:before {
+.sf-rhode-island:before,
+.sf-ri:before,
+.sf-44:before {
   content: "m";
 }
 
-.sf-south-carolina:before {
+.sf-south-carolina:before,
+.sf-sc:before,
+.sf-45:before {
   content: "n";
 }
 
-.sf-south-dakota:before {
+.sf-south-dakota:before,
+.sf-sd:before,
+.sf-46:before {
   content: "o";
 }
 
-.sf-tennessee:before {
+.sf-tennessee:before,
+.sf-tn:before,
+.sf-47:before {
   content: "p";
 }
 
-.sf-texas:before {
+.sf-texas:before,
+.sf-tx:before,
+.sf-48:before {
   content: "q";
 }
 
-.sf-utah:before {
+.sf-utah:before,
+.sf-ut:before,
+.sf-49:before {
   content: "r";
 }
 
-.sf-vermont:before {
+.sf-vermont:before,
+.sf-vt:before,
+.sf-50:before {
   content: "t";
 }
 
-.sf-virginia:before {
+.sf-virginia:before,
+.sf-va:before,
+.sf-51:before {
   content: "s";
 }
 
-.sf-washington:before {
+.sf-washington:before,
+.sf-wa:before,
+.sf-53:before {
   content: "u";
 }
 
-.sf-west-virginia:before {
+.sf-west-virginia:before,
+.sf-wv:before,
+.sf-54:before {
   content: "w";
 }
 
-.sf-wisconsin:before {
+.sf-wisconsin:before,
+.sf-wi:before,
+.sf-55:before {
   content: "v";
 }
 
-.sf-wyoming:before {
+.sf-wyoming:before,
+.sf-wy:before,
+.sf-56:before {
   content: "x";
+}
+
+.sf-district-of-columbia:before,
+.sf-dc:before,
+.sf-11001:before {
+  content: "y";
+}
+
+.sf-puerto-rico:before,
+.sf-pr:before,
+.sf-72:before {
+  content: "3";
+}
+
+.sf-guam:before,
+.sf-gu:before,
+.sf-66:before {
+  content: "4";
 }

--- a/reference/stateface.scss
+++ b/reference/stateface.scss
@@ -1,6 +1,10 @@
 /*
 * SASS for http://propublica.github.io/stateface/ icon set.
 * author: https://github.com/amurrell
+
+* also adopted some code from other contributors:
+*  - replacement: Paul Smith https://github.com/paulsmith
+*  - FIPS state abbreviations: https://github.com/joetric
 */
 
 @font-face {
@@ -47,62 +51,69 @@
 
 /* Icons */
 $state_face:
-    "alabama" "B",
-    "alaska" "A",
-    "arizona" "D",
-    "arkansas" "C",
-    "california" "E",
-    "colorado" "F",
-    "connecticut" "G",
-    "delaware" "H",
-    "florida" "I",
-    "georgia" "J",
-    "hawaii" "K",
-    "idaho" "M",
-    "illinois" "N",
-    "indiana" "O",
-    "iowa" "L",
-    "kansas" "P",
-    "kentucky" "Q",
-    "louisiana" "R",
-    "maine" "U",
-    "maryland" "T",
-    "massachusetts" "S",
-    "michigan" "V",
-    "minnesota" "W",
-    "mississippi" "Y",
-    "missouri" "X",
-    "montana" "Z",
-    "nebraska" "c",
-    "nevada" "g",
-    "new-hampshire" "d",
-    "new-jersey" "e",
-    "new-mexico" "f",
-    "new-york" "h",
-    "north-carolina" "a",
-    "north-dakota" "b",
-    "ohio" "i",
-    "oklahoma" "j",
-    "oregon" "k",
-    "pennsylvania" "l",
-    "rhode-island" "m",
-    "south-carolina" "n",
-    "south-dakota" "o",
-    "tennessee" "p",
-    "texas" "q",
-    "utah" "r",
-    "vermont" "t",
-    "virginia" "s",
-    "washington" "u",
-    "west-virginia" "w",
-    "wisconsin" "v",
-    "wyoming" "x";
+    "alabama" "al" "01" "B",
+    "alaska" "ak" "02" "A",
+    "arizona" "az" "04" "D",
+    "arkansas" "ar" "05" "C",
+    "california" "ca" "06" "E",
+    "colorado" "co" "08" "F",
+    "connecticut" "ct" "09" "G",
+    "delaware" "de" "10" "H",
+    "florida" "fl" "12" "I",
+    "georgia" "ga" "13" "J",
+    "hawaii" "hi" "15" "K",
+    "idaho" "id" "16" "M",
+    "illinois" "il" "17" "N",
+    "indiana" "in" "18" "O",
+    "iowa" "ia" "19" "L",
+    "kansas" "ks" "20" "P",
+    "kentucky" "ky" "21" "Q",
+    "louisiana" "la" "22" "R",
+    "maine" "me" "23" "U",
+    "maryland" "md" "24" "T",
+    "massachusetts" "ma" "25" "S",
+    "michigan" "mi" "26" "V",
+    "minnesota" "mn" "27" "W",
+    "mississippi" "ms" "28" "Y",
+    "missouri" "mo" "29" "X",
+    "montana" "mt" "30" "Z",
+    "nebraska" "ne" "31" "c",
+    "nevada" "nv" "32" "g",
+    "new-hampshire" "nh" "33" "d",
+    "new-jersey" "nj" "34" "e",
+    "new-mexico" "nm" "35" "f",
+    "new-york" "ny" "36" "h",
+    "north-carolina" "nc" "37" "a",
+    "north-dakota" "nd" "38" "b",
+    "ohio" "oh" "39" "i",
+    "oklahoma" "ok" "40" "j",
+    "oregon" "or" "41" "k",
+    "pennsylvania" "pa" "42" "l",
+    "rhode-island" "ri" "44" "m",
+    "south-carolina" "sc" "45" "n",
+    "south-dakota" "sd" "46" "o",
+    "tennessee" "tn" "47" "p",
+    "texas" "tx" "48" "q",
+    "utah" "ut" "49" "r",
+    "vermont" "vt" "50" "t",
+    "virginia" "va" "51" "s",
+    "washington" "wa" "53" "u",
+    "west-virginia" "wv" "54" "w",
+    "wisconsin" "wi" "55" "v",
+    "wyoming" "wy" "56" "x",
+    "district-of-columbia" "dc" "11001" "y",
+    "puerto-rico" "pr" "72" "3",
+    "guam" "gu" "66" "4";
+
     
 @each $i in $state_face {
-    .sf-#{nth($i, 1)} {
+    .sf-#{nth($i, 1)},
+    .sf-#{nth($i, 2)},
+    .sf-#{nth($i, 3)},
+    {
 	@extend %state-face;
 	&:before {
-	    content: nth($i, 2);
+	    content: nth($i, 4);
 	}
     }
 }

--- a/reference/stateface.scss
+++ b/reference/stateface.scss
@@ -1,0 +1,108 @@
+/*
+* SASS for http://propublica.github.io/stateface/ icon set.
+* author: https://github.com/amurrell
+*/
+
+@font-face {
+    font-family: 'sf-regular';
+    src: url('../font/webfont/stateface-regular-webfont.eot');
+    src: url('../font/webfont/stateface-regular-webfont.eot?#iefix') format('embedded-opentype'),
+	url('../font/webfont/stateface-regular-webfont.woff') format('woff'),
+	url('../font/webfont/stateface-regular-webfont.ttf') format('truetype'),
+	url('../font/webfont/stateface-regular-webfont.svg#sf-regular') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}
+
+
+%state-face {
+    &.sf-replace {
+	text-indent: -999em;
+	display: inline-block;
+	position: relative;
+	min-width: 1em;
+    }
+    &:before {
+	font-family:"sf-regular";
+	margin-right: 5px;
+	display:inline-block;
+	vertical-align:middle;
+	line-height:1;
+	font-weight:normal;
+	font-style:normal;
+	speak:none;
+	text-decoration:inherit;
+	text-transform:none;
+	text-rendering:optimizeLegibility;
+	-webkit-font-smoothing:antialiased;
+	-moz-osx-font-smoothing:grayscale;
+    }
+    &.sf-replace:before {
+	position: absolute;
+	left: 0;
+	top: 0;
+	text-indent: 0;
+    }
+}
+
+/* Icons */
+$state_face:
+    "alabama" "B",
+    "alaska" "A",
+    "arizona" "D",
+    "arkansas" "C",
+    "california" "E",
+    "colorado" "F",
+    "connecticut" "G",
+    "delaware" "H",
+    "florida" "I",
+    "georgia" "J",
+    "hawaii" "K",
+    "idaho" "M",
+    "illinois" "N",
+    "indiana" "O",
+    "iowa" "L",
+    "kansas" "P",
+    "kentucky" "Q",
+    "louisiana" "R",
+    "maine" "U",
+    "maryland" "T",
+    "massachusetts" "S",
+    "michigan" "V",
+    "minnesota" "W",
+    "mississippi" "Y",
+    "missouri" "X",
+    "montana" "Z",
+    "nebraska" "c",
+    "nevada" "g",
+    "new-hampshire" "d",
+    "new-jersey" "e",
+    "new-mexico" "f",
+    "new-york" "h",
+    "north-carolina" "a",
+    "north-dakota" "b",
+    "ohio" "i",
+    "oklahoma" "j",
+    "oregon" "k",
+    "pennsylvania" "l",
+    "rhode-island" "m",
+    "south-carolina" "n",
+    "south-dakota" "o",
+    "tennessee" "p",
+    "texas" "q",
+    "utah" "r",
+    "vermont" "t",
+    "virginia" "s",
+    "washington" "u",
+    "west-virginia" "w",
+    "wisconsin" "v",
+    "wyoming" "x";
+    
+@each $i in $state_face {
+    .sf-#{nth($i, 1)} {
+	@extend %state-face;
+	&:before {
+	    content: nth($i, 2);
+	}
+    }
+}


### PR DESCRIPTION
I added FIPS support, as well as full state-names, and state abbreviations.

Notice that I included this information in the documentation.

Oh, there's also support for Guam for whenever you make that icon.