### PR TITLE
Update link to Glyphs Mini on docs site

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@
 
 <h2>Forking and Contributing</h2>
 
-<p>The <a href="http://itunes.apple.com/us/app/glyphs-mini/id469036911?mt=12">Glyphs Mini</a> <code>.glyphs</code> file is <a href="font/stateface.glyphs">included in the repo</a> if any type (especially hinting) experts want to try their hand at tuning it.</p>
+<p>The <a href="https://glyphsapp.com/glyphs-mini">Glyphs Mini</a> <code>.glyphs</code> file is <a href="font/stateface.glyphs">included in the repo</a> if any type (especially hinting) experts want to try their hand at tuning it.</p>
 
 <p>FontSquirrel's <a href="http://www.fontsquirrel.com/fontface/generator">FontFace Generator</a> generated the files in <code>font/webfont</code>.</p>
 


### PR DESCRIPTION
…since it doesn't seem to be in the Mac App Store anymore.